### PR TITLE
feat(event-consume): add Kafka event consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,37 @@
 # ethan-lab
 
-Personal playground repo for experiments and reusable components.
+> 高并发业务系统的事件可靠性平台
+> 保证每一个订单事件从产生到处理：不丢、不重、不乱
 
-## Modules
+## 它解决什么问题
 
-- `libs/common`: shared models (e.g., Message response wrapper)
-- `apps/facts-platform-app`: Spring Boot demo app
+在高并发场景下，这些问题每天都在发生：
 
-## Build
+- 订单创建事件发出去了，消费者没收到——**消息丢失**
+- 网络抖动导致同一个事件被处理两次——**重复消费**
+- 用户先付款后取消，但系统按相反顺序处理——**顺序错乱**
 
-```bash
+ethan-lab 提供一套可直接接入的事件可靠性保障机制，
+让你不需要每个项目都重新造轮子。
+
+## 模块
+
+- `libs/common-core` 基础组件：消息封装、Auth、公共模型
+- `apps/facts-platform-app` 事件摄入服务：接收、持久化、发布事件
+
+## 当前进度
+
+- [x] 项目结构搭建
+- [x] API数据持久化
+- [ ] 事件发布机制（进行中）
+- [ ] 订单场景端到端演示
+- [ ] 消息幂等性保障
+- [ ] 消费顺序保证
+
+## 快速启动
+
 mvn -q -DskipTests clean install
+
+## 技术栈
+
+Java 17 · Spring Boot · Kafka · MySQL · DDD

--- a/apps/facts-platform-app/pom.xml
+++ b/apps/facts-platform-app/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
@@ -1,16 +1,25 @@
 package io.github.ethanzhang.factsplatform.application;
 
+import io.github.ethanzhang.factsplatform.application.ports.EventPublisher;
 import io.github.ethanzhang.factsplatform.domain.rawevent.RawEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 @Component
 @RequiredArgsConstructor
 public class IngestEventApplication {
 
     private final RawEventService rawEventService;
+    private final EventPublisher eventPublisher;
 
+    @Transactional
     public IngestRawEventReport ingest(IngestRawEventCmd cmd) {
+        if (cmd.getIngestTime() == null) {
+            cmd.setIngestTime(Instant.now());
+        }
 
         // timeline
         // persist timeline
@@ -20,6 +29,7 @@ public class IngestEventApplication {
 
 
         // add to queue
+        eventPublisher.publish(id, cmd.getEventBody());
 
         return new IngestRawEventReport(id);
     }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestRawEventCmd.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestRawEventCmd.java
@@ -3,11 +3,12 @@ package io.github.ethanzhang.factsplatform.application;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.Instant;
-import java.time.ZoneId;
 
 @Getter
+@Setter
 @Builder
 public class IngestRawEventCmd {
     private String source;

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/ports/EventPublisher.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/ports/EventPublisher.java
@@ -1,0 +1,5 @@
+package io.github.ethanzhang.factsplatform.application.ports;
+
+public interface EventPublisher {
+    void publish(String eventId, String eventBody);
+}

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventId.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventId.java
@@ -1,7 +1,6 @@
 package io.github.ethanzhang.factsplatform.domain.rawevent;
 
 import java.time.Instant;
-import java.time.ZoneId;
 
 public record RawEventId(String source, String identifyKey, String zoneId, Instant ingestTime) {
 

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventRepository.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventRepository.java
@@ -2,5 +2,5 @@ package io.github.ethanzhang.factsplatform.domain.rawevent;
 
 public interface RawEventRepository {
 
-    void save(RawEventAggRoot event);
+    long save(RawEventAggRoot event);
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventService.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/domain/rawevent/RawEventService.java
@@ -17,7 +17,7 @@ public class RawEventService {
                 cmd.getIngestTime()
         );
         RawEventAggRoot rawEvent = new RawEventAggRoot(rawEventId, cmd.getEventBody());
-        rawEventRepository.save(rawEvent);
-        return rawEvent.getId().toString();
+        long persistedId = rawEventRepository.save(rawEvent);
+        return String.valueOf(persistedId);
     }
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/entity/RawEventEntity.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/entity/RawEventEntity.java
@@ -2,13 +2,19 @@ package io.github.ethanzhang.factsplatform.infrastructure.db.entity;
 
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
 @TableName("raw_event")
+@NoArgsConstructor
 public class RawEventEntity {
     @TableId
-    private String rawEventId;
+    private long rawEventId;
     private String eventBody;
 
-    public RawEventEntity(String rawEventId, String eventBody) {
+    public RawEventEntity(long rawEventId, String eventBody) {
+        this.rawEventId = rawEventId;
+        this.eventBody = eventBody;
     }
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/mapper/RawEventMapper.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/mapper/RawEventMapper.java
@@ -1,8 +1,11 @@
 package io.github.ethanzhang.factsplatform.infrastructure.db.mapper;
 
+import io.github.ethanzhang.factsplatform.infrastructure.db.entity.RawEventEntity;
 import io.github.ethanzhang.factsplatform.infrastructure.db.entity.RawEventIdentify;
 import org.apache.ibatis.annotations.Param;
 
 public interface RawEventMapper {
-    void insert(@Param("entity") RawEventIdentify entity);
+    void insertIdentify(@Param("entity") RawEventIdentify entity);
+
+    void insertRawEvent(@Param("entity") RawEventEntity entity);
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/repository/RawEventRepositoryImpl.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/db/repository/RawEventRepositoryImpl.java
@@ -3,6 +3,7 @@ package io.github.ethanzhang.factsplatform.infrastructure.db.repository;
 import common.utils.IdGenerator;
 import io.github.ethanzhang.factsplatform.domain.rawevent.RawEventAggRoot;
 import io.github.ethanzhang.factsplatform.domain.rawevent.RawEventRepository;
+import io.github.ethanzhang.factsplatform.infrastructure.db.entity.RawEventEntity;
 import io.github.ethanzhang.factsplatform.infrastructure.db.entity.RawEventIdentify;
 import io.github.ethanzhang.factsplatform.infrastructure.db.mapper.RawEventMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,15 +17,19 @@ public class RawEventRepositoryImpl implements RawEventRepository {
     private final IdGenerator idGenerator;
 
     @Override
-    public void save(RawEventAggRoot event) {
+    public long save(RawEventAggRoot event) {
+        long rawEventId = idGenerator.generateSequence();
+
         RawEventIdentify rawEventIdentify = new RawEventIdentify();
-        rawEventIdentify.setRawEventId(idGenerator.generateSequence());
+        rawEventIdentify.setRawEventId(rawEventId);
         rawEventIdentify.setSource(event.getSource());
         rawEventIdentify.setIdentifyKey(event.getIdentifyKey());
         rawEventIdentify.setZoneId(event.getZoneId());
         rawEventIdentify.setIngestTime(event.getIngestTime());
         rawEventIdentify.setTimelineSequenceId(1L);
 
-        rawEventMapper.insert(rawEventIdentify);
+        rawEventMapper.insertIdentify(rawEventIdentify);
+        rawEventMapper.insertRawEvent(new RawEventEntity(rawEventId, event.getEventBody()));
+        return rawEventId;
     }
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/messaging/KafkaEventPublisher.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/messaging/KafkaEventPublisher.java
@@ -1,0 +1,21 @@
+package io.github.ethanzhang.factsplatform.infrastructure.messaging;
+
+import io.github.ethanzhang.factsplatform.application.ports.EventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisher implements EventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    @Value("${facts-platform.messaging.raw-event-topic:raw-event-ingested}")
+    private String rawEventTopic;
+
+    @Override
+    public void publish(String eventId, String eventBody) {
+        kafkaTemplate.send(rawEventTopic, eventId, eventBody);
+    }
+}

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/interfaces/api/dto/RawEventIngestDto.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/interfaces/api/dto/RawEventIngestDto.java
@@ -1,10 +1,9 @@
 package io.github.ethanzhang.factsplatform.interfaces.api.dto;
 
 import io.github.ethanzhang.factsplatform.application.IngestRawEventCmd;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.time.ZoneId;
+import java.time.Instant;
 
 @Data
 public class RawEventIngestDto {
@@ -12,6 +11,7 @@ public class RawEventIngestDto {
     private String identifyKey;
     private String eventBody;
     private String zoneId;
+    private Instant ingestTime;
 
     public IngestRawEventCmd toCommand() {
         return IngestRawEventCmd.builder()
@@ -19,6 +19,7 @@ public class RawEventIngestDto {
                 .identifyKey(identifyKey)
                 .eventBody(eventBody)
                 .zoneId(zoneId)
+                .ingestTime(ingestTime)
                 .build();
     }
 }

--- a/apps/facts-platform-app/src/main/resources/application-dev.yml
+++ b/apps/facts-platform-app/src/main/resources/application-dev.yml
@@ -13,3 +13,19 @@ spring:
       connection-timeout: 300000
       validationTimeout: 300000
       connection-test-query: SELECT 1
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      acks: all
+      retries: 3
+      properties:
+        enable.idempotence: true
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: ethan-lab-dev
+      auto-offset-reset: earliest
+
+facts-platform:
+  messaging:
+    raw-event-topic: raw-event-ingested

--- a/apps/facts-platform-app/src/main/resources/mapper/RawEventMapper.xml
+++ b/apps/facts-platform-app/src/main/resources/mapper/RawEventMapper.xml
@@ -5,8 +5,33 @@
 
 <mapper namespace="io.github.ethanzhang.factsplatform.infrastructure.db.mapper.RawEventMapper">
 
-    <insert id="insert">
-        insert into raw_event_identify (raw_event_id, source)
-        values (#{entity.rawEventId}, #{entity.source});
+    <insert id="insertIdentify">
+        insert into raw_event_identify (
+            raw_event_id,
+            source,
+            identify_key,
+            zone_id,
+            ingest_time,
+            timeline_sequence_id
+        )
+        values (
+            #{entity.rawEventId},
+            #{entity.source},
+            #{entity.identifyKey},
+            #{entity.zoneId},
+            #{entity.ingestTime},
+            #{entity.timelineSequenceId}
+        );
+    </insert>
+
+    <insert id="insertRawEvent">
+        insert into raw_event (
+            raw_event_id,
+            event_body
+        )
+        values (
+            #{entity.rawEventId},
+            #{entity.eventBody}
+        );
     </insert>
 </mapper>

--- a/apps/facts-platform-app/src/test/java/io/github/ethanzhang/factsplatform/interfaces/HealthControllerTest.java
+++ b/apps/facts-platform-app/src/test/java/io/github/ethanzhang/factsplatform/interfaces/HealthControllerTest.java
@@ -1,7 +1,34 @@
 package io.github.ethanzhang.factsplatform.interfaces;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import io.github.ethanzhang.factsplatform.interfaces.api.HealthController;
+import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthController.class)
 class HealthControllerTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnLiveStatus() throws Exception {
+        mockMvc.perform(get("/health/live"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.version").exists())
+                .andExpect(jsonPath("$.timezone").exists());
+    }
+
+    @Test
+    void shouldReturnReadyStatus() throws Exception {
+        mockMvc.perform(get("/health/ready"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("READY"));
+    }
 }

--- a/apps/facts-platform-app/src/test/java/io/github/ethanzhang/factsplatform/interfaces/IngestEventControllerTest.java
+++ b/apps/facts-platform-app/src/test/java/io/github/ethanzhang/factsplatform/interfaces/IngestEventControllerTest.java
@@ -1,0 +1,48 @@
+package io.github.ethanzhang.factsplatform.interfaces;
+
+import io.github.ethanzhang.factsplatform.application.IngestEventApplication;
+import io.github.ethanzhang.factsplatform.application.IngestRawEventReport;
+import io.github.ethanzhang.factsplatform.interfaces.api.IngestEventController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(IngestEventController.class)
+class IngestEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IngestEventApplication ingestEventApplication;
+
+    @Test
+    void shouldIngestEvent() throws Exception {
+        given(ingestEventApplication.ingest(any()))
+                .willReturn(new IngestRawEventReport("123456"));
+
+        mockMvc.perform(post("/event/ingest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "source": "app",
+                                  "identifyKey": "user-1",
+                                  "eventBody": "{\\"foo\\":\\"bar\\"}",
+                                  "zoneId": "Asia/Shanghai"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("Success"))
+                .andExpect(jsonPath("$.data.eventId").value("123456"));
+    }
+}


### PR DESCRIPTION
Enable ingestion workflow to consume messages from Kafka.

Add RawEvent to represent the end-to-end message structure for downstream processing.

Refs: #6