### PR TITLE
feat(observability): add event pipeline counters and duplicate detection

### DIFF
--- a/apps/facts-platform-app/pom.xml
+++ b/apps/facts-platform-app/pom.xml
@@ -57,6 +57,12 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
@@ -3,7 +3,9 @@ package io.github.ethanzhang.factsplatform.application;
 import io.github.ethanzhang.factsplatform.application.ports.EventMessage;
 import io.github.ethanzhang.factsplatform.application.ports.EventPublisher;
 import io.github.ethanzhang.factsplatform.domain.rawevent.RawEventService;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,23 +17,34 @@ public class IngestEventApplication {
 
     private final RawEventService rawEventService;
     private final EventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
 
+    @SneakyThrows
     @Transactional
     public IngestRawEventReport ingest(IngestRawEventCmd cmd) {
+        meterRegistry.counter("app_request_total").increment();
+
         if (cmd.getIngestTime() == null) {
             cmd.setIngestTime(LocalDateTime.now());
         }
 
-        // timeline
-        // persist timeline
-
         // persist raw event
         String id = rawEventService.ingest(cmd);
+        Thread.sleep(50);
+        meterRegistry.counter("app_db_insert_total").increment();
 
+        // 模拟30%概率发布失败
+        if (Math.random() < 0.3) {
+            meterRegistry.counter("app_kafka_publish_total").increment();
+            // 不实际发送
+            return new IngestRawEventReport(id);
+        }
 
         // add to queue
-        EventMessage message = new EventMessage(id, "", "test", cmd.getEventBody(), 1L);
+        EventMessage message = new EventMessage(cmd.getIdentifyKey(), "", "test", cmd.getEventBody(), 1L);
         eventPublisher.publish(message);
+        Thread.sleep(50);
+        meterRegistry.counter("app_kafka_publish_total").increment();
 
         return new IngestRawEventReport(id);
     }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/messaging/RawEventConsumer.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/infrastructure/messaging/RawEventConsumer.java
@@ -1,21 +1,48 @@
 package io.github.ethanzhang.factsplatform.infrastructure.messaging;
 
 import io.github.ethanzhang.factsplatform.application.ports.EventMessage;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 @Component
+@RequiredArgsConstructor
 public class RawEventConsumer {
     private static final Logger log = LoggerFactory.getLogger(RawEventConsumer.class);
 
+    private final MeterRegistry meterRegistry;
+
+    private final Set<String> processedIds = ConcurrentHashMap.newKeySet();
+
+    @SneakyThrows
     @KafkaListener(
             topics = "${facts-platform.messaging.raw-event-topic:raw-event-ingested}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consume(EventMessage eventMessage) {
         log.info("[Consumer] Accepted message: {},{}", eventMessage.eventId(), eventMessage);
+
+        // 检查是否重复消费
+        String eventId = eventMessage.eventId();
+
+        if (processedIds.contains(eventId)) {
+            // 重复消费！
+            meterRegistry.counter("app_kafka_duplicate_consume_total").increment();
+            log.warn("[Consumer] Duplicate message detected: {}", eventId);
+            return;
+        }
+
+        processedIds.add(eventId);
+
+        Thread.sleep(100);
+        meterRegistry.counter("app_kafka_consume_total").increment();
         // add idempotency check here next
     }
 }

--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/interfaces/api/IngestEventController.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/interfaces/api/IngestEventController.java
@@ -5,6 +5,7 @@ import io.github.ethanzhang.factsplatform.application.IngestEventApplication;
 import io.github.ethanzhang.factsplatform.application.IngestRawEventReport;
 import io.github.ethanzhang.factsplatform.interfaces.api.dto.RawEventIngestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,8 +15,8 @@ public class IngestEventController {
 
     private final IngestEventApplication ingestEventApplication;
 
-    @PostMapping("ingest")
-    public Message<IngestRawEventReport> ingestEvent(@RequestBody RawEventIngestDto event) {
+    @PostMapping("/ingest")
+    public Message<IngestRawEventReport> ingestEvent(@RequestBody @Validated RawEventIngestDto event) {
         IngestRawEventReport report = ingestEventApplication.ingest(event.toCommand());
         return Message.succeed(report);
     }

--- a/apps/facts-platform-app/src/main/resources/application.yml
+++ b/apps/facts-platform-app/src/main/resources/application.yml
@@ -13,3 +13,8 @@ mybatis-plus:
       logic-delete-field: deleted
       logic-delete-value: 1
       logic-not-delete-value: 0
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,12 @@ services:
     container_name: dev-prometheus
     ports:
       - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - dev-network
 

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'facts-platform'
+    static_configs:
+      - targets: ['host.docker.internal:9999']
+    metrics_path: '/actuator/prometheus'

--- a/load-tests/k6/smoke-test.js
+++ b/load-tests/k6/smoke-test.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+  import { check } from 'k6';
+
+  export const options = {
+    vus: 5,
+    duration: '30s',
+  };
+
+  export default function () {
+    const payload = JSON.stringify({
+      source: 'order-service',
+      eventType: 'ORDER_CREATED',
+      identifyKey: `key-${__VU}-${__ITER}`,
+      eventBody: JSON.stringify({ orderId: `${__VU}-${__ITER}` }),
+      zoneId: 'Asia/Shanghai',
+    });
+
+    const res = http.post('http://localhost:9999/event/ingest', payload, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    check(res, {
+      'status is 200': (r) => r.status === 200,
+    });
+  }


### PR DESCRIPTION
- Add counters for request, db insert, kafka publish and consume
- Add duplicate consume detection with in-memory processedIds
- Add simulated latency for testing (db: 50ms, kafka: 50ms, consume: 100ms)