### PR TITLE
test: add k6 load test script for ingest endpoint

### DIFF
--- a/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
+++ b/apps/facts-platform-app/src/main/java/io/github/ethanzhang/factsplatform/application/IngestEventApplication.java
@@ -35,9 +35,8 @@ public class IngestEventApplication {
 
         // 模拟30%概率发布失败
         if (Math.random() < 0.3) {
-            meterRegistry.counter("app_kafka_publish_total").increment();
-            // 不实际发送
-            return new IngestRawEventReport(id);
+            meterRegistry.counter("app_kafka_publish_failed_total").increment();
+            throw new RuntimeException("Simulated publish failure");
         }
 
         // add to queue

--- a/load-tests/k6/test.js
+++ b/load-tests/k6/test.js
@@ -1,0 +1,55 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const duplicateRequests = new Counter('duplicate_requests');
+const ingestTrend = new Trend('ingest_duration');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 50 },
+    { duration: '1m',  target: 100 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(99)<500'],
+    http_req_failed:   ['rate<0.01'],
+    ingest_duration:   ['p(95)<300'],
+  },
+};
+
+export default function () {
+
+  // 10%概率发送重复key，测试幂等机制
+  const isDuplicate = Math.random() < 0.1;
+  const identifyKey = isDuplicate
+    ? `key-${__VU}-0`
+    : `key-${__VU}-${__ITER}`;
+
+  if (isDuplicate) {
+    duplicateRequests.add(1);
+  }
+
+  const payload = JSON.stringify({
+    source:      'order-service',
+    eventType:   'ORDER_CREATED',
+    identifyKey: identifyKey,
+    eventBody:   JSON.stringify({ orderId: `${__VU}-${__ITER}` }),
+    zoneId:      'Asia/Shanghai',
+  });
+
+  const res = http.post(
+    'http://localhost:9999/event/ingest',
+    payload,
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+
+  ingestTrend.add(res.timings.duration);
+
+  check(res, {
+    'status is 200':        (r) => r.status === 200,
+    'response time < 500ms':(r) => r.timings.duration < 500,
+  });
+
+  sleep(0.1);
+}


### PR DESCRIPTION
- 100 concurrent users via 3-stage ramp-up
- 10% duplicate key injection to test idempotency
- Custom metrics: duplicate_requests, ingest_duration
- Thresholds: p(99)<500ms, failure rate <1%
- Refine Kafka publish error mocking